### PR TITLE
feat!: output WKT geometry in original SRSs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Get latest version](https://img.shields.io/npm/v/%40rdmr-eu/rdf-geopackage)](https://www.npmjs.com/package/@rdmr-eu/rdf-geopackage)
 
-
 Generate RDF out of a GeoPackage (for further processing)
 
 ## Usage
@@ -89,3 +88,11 @@ xyz:nga_properties a fx:root ;
 
 [geosparql]: https://www.ogc.org/standard/geosparql/
 [example.gpkg]: https://github.com/ngageoint/GeoPackage/blob/master/docs/examples/java/example.gpkg
+
+# Acknowledgements
+
+This tool was developed for a project funded by the [_City Deal Openbare ruimte_][cdor],
+executed by [Stichting Kennisplatform CROW][crow].
+
+[crow]: https://crow.nl/
+[cdor]: https://www.citydealopenbareruimte.nl/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ngageoint/geopackage": "^4.2.4",
-        "@ngageoint/simple-features-geojson-js": "^1.1.1",
-        "@ngageoint/simple-features-wkt-js": "^1.1.1",
         "better-sqlite3": "^8.7.0",
         "geojson": "^0.5.0",
         "json-stable-stringify": "^1.0.2",
@@ -32,6 +30,7 @@
         "@types/json-stable-stringify": "^1.0.34",
         "@types/n3": "^1.16.0",
         "@types/node": "^20.8.8",
+        "@types/proj4": "^2.5.4",
         "@types/yargs": "^17.0.24",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
@@ -1303,6 +1302,11 @@
         "inquirer": "8.0.0"
       }
     },
+    "node_modules/@ngageoint/geopackage/node_modules/@types/proj4": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.2.tgz",
+      "integrity": "sha512-/Nmfn9p08yaYw6xo5f2b0L+2oHk2kZeOkp5v+4VCeNfq+ETlLQbmHmC97/pjDIEZy8jxwz7pdPpwNzDHM5cuJw=="
+    },
     "node_modules/@ngageoint/geopackage/node_modules/better-sqlite3": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.4.1.tgz",
@@ -1396,6 +1400,21 @@
         "wkt-parser": "^1.3.1"
       }
     },
+    "node_modules/@ngageoint/geopackage/node_modules/reproject": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.2.5.tgz",
+      "integrity": "sha512-cTH78fi1uuv5gzW/GVepO4LbCvOUhO0X2BEyyvrKkYb4KPRmDPs7cZnIxemHPUIch/CoSI8MPLmXRHZFSHjbKw==",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "event-stream": "^4.0.0",
+        "geojson-stream": "0.1.0",
+        "minimist": "^1.2.0",
+        "proj4": "^2.4.4"
+      },
+      "bin": {
+        "reproject": "cli.js"
+      }
+    },
     "node_modules/@ngageoint/geopackage/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -1416,35 +1435,12 @@
         "simple-concat": "^1.0.0"
       }
     },
-    "node_modules/@ngageoint/simple-features-geojson-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@ngageoint/simple-features-geojson-js/-/simple-features-geojson-js-1.1.1.tgz",
-      "integrity": "sha512-itKgLRi32tCfNgaW8eIT8ojqjkHXIGJYh61hNzn/I+WLHsKApoKEJ4SsfqlaPTGeHnOXu3llaWedrmf3rx8/fw==",
+    "node_modules/@ngageoint/geopackage/node_modules/wkx": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
+      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
       "dependencies": {
-        "@ngageoint/simple-features-js": "1.1.1",
-        "@types/geojson": "7946.0.10"
-      }
-    },
-    "node_modules/@ngageoint/simple-features-geojson-js/node_modules/@types/geojson": {
-      "version": "7946.0.10",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
-      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
-    },
-    "node_modules/@ngageoint/simple-features-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@ngageoint/simple-features-js/-/simple-features-js-1.1.1.tgz",
-      "integrity": "sha512-n8drsuGRONnDTKG0Gn7OZ69cVoq4yC2qCo7hi22LY52lYrpPgDfu8U2TgRZWf/JXFK3WwNZ7AHgCmyAzHzYNlg==",
-      "dependencies": {
-        "js_cols": "1.0.1",
-        "timsort": "^0.3.0"
-      }
-    },
-    "node_modules/@ngageoint/simple-features-wkt-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@ngageoint/simple-features-wkt-js/-/simple-features-wkt-js-1.1.1.tgz",
-      "integrity": "sha512-vM+pDkD3rtIkWI5ITpOW4o4mNDXUlYSgkcYh6i8CUqvZYdNEyyHh02dGARhl9fzlZgyIb4latuc3CX/Lt4kRyQ==",
-      "dependencies": {
-        "@ngageoint/simple-features-js": "1.1.1"
+        "@types/node": "*"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1871,11 +1867,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.8.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.8.tgz",
-      "integrity": "sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==",
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
+      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1885,9 +1881,10 @@
       "dev": true
     },
     "node_modules/@types/proj4": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.2.tgz",
-      "integrity": "sha512-/Nmfn9p08yaYw6xo5f2b0L+2oHk2kZeOkp5v+4VCeNfq+ETlLQbmHmC97/pjDIEZy8jxwz7pdPpwNzDHM5cuJw=="
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.4.tgz",
+      "integrity": "sha512-AAqZQKgOGuEmhlfLgues7anx0vcZg+0xKE8UggfVnWJSKk4xdVm+Rg1q2q7YmqoZS51BJ5jTcCyYQqIGdxa8FQ==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.2",
@@ -3234,9 +3231,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "27.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.4.3.tgz",
-      "integrity": "sha512-7S6SmmsHsgIm06BAGCAxL+ABd9/IB3MWkz2pudj6Qqor2y1qQpWPfuFU4SG9pWj4xDjF0e+D7Llh5useuSzAZw==",
+      "version": "27.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.6.0.tgz",
+      "integrity": "sha512-MTlusnnDMChbElsszJvrwD1dN3x6nZl//s4JD23BxB6MgR66TZlL064su24xEIS3VACfAoHV1vgyMgPw8nkdng==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.10.0"
@@ -5112,11 +5109,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js_cols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/js_cols/-/js_cols-1.0.1.tgz",
-      "integrity": "sha512-VJuDOf7txQznLQSlJ7p90Cawz5A1+T4MsOYF01V1WqK7TJOnHvvC8Oz8qtc7KDfDyfP05jP5ua7VOpUm/S6s+g=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6022,9 +6014,9 @@
       "optional": true
     },
     "node_modules/proj4": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.1.tgz",
-      "integrity": "sha512-hhquvYHnqz8nf8U9CODRLGSL7bUg4p5oVkZI4oWxX7whNcSbn2xdNA1WnF1jye+ezrtuSiPVao9LEHlKeQA5uA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.2.tgz",
+      "integrity": "sha512-bdyfNmtlWjQN/rHEHEiqFvpTUHhuzDaeQ6Uu1G4sPGqk+Xkxae6ahh865fClJokSGPBmlDOQWWaO6465TCfv5Q==",
       "dependencies": {
         "mgrs": "1.0.0",
         "wkt-parser": "^1.3.3"
@@ -6286,21 +6278,6 @@
       "dev": true,
       "bin": {
         "regexp-tree": "bin/regexp-tree"
-      }
-    },
-    "node_modules/reproject": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/reproject/-/reproject-1.2.5.tgz",
-      "integrity": "sha512-cTH78fi1uuv5gzW/GVepO4LbCvOUhO0X2BEyyvrKkYb4KPRmDPs7cZnIxemHPUIch/CoSI8MPLmXRHZFSHjbKw==",
-      "dependencies": {
-        "concat-stream": "^2.0.0",
-        "event-stream": "^4.0.0",
-        "geojson-stream": "0.1.0",
-        "minimist": "^1.2.0",
-        "proj4": "^2.4.4"
-      },
-      "bin": {
-        "reproject": "cli.js"
       }
     },
     "node_modules/require-directory": {
@@ -6910,11 +6887,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
-    "node_modules/timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A=="
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -7093,9 +7065,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -7215,14 +7187,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
       "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
-    },
-    "node_modules/wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,13 @@
   ],
   "types": "dist/rdf-geopackage.d.ts",
   "type": "module",
-  "keywords": [],
+  "keywords": [
+    "geojson",
+    "geosparql",
+    "rdf",
+    "geopackage",
+    "linked-data"
+  ],
   "author": "Redmer Kronemeijer <12477216+redmer@users.noreply.github.com> (https://rdmr.eu/)",
   "license": "MPL-2.0",
   "prettier": {},
@@ -48,6 +54,7 @@
     "@types/json-stable-stringify": "^1.0.34",
     "@types/n3": "^1.16.0",
     "@types/node": "^20.8.8",
+    "@types/proj4": "^2.5.4",
     "@types/yargs": "^17.0.24",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
@@ -61,8 +68,6 @@
   },
   "dependencies": {
     "@ngageoint/geopackage": "^4.2.4",
-    "@ngageoint/simple-features-geojson-js": "^1.1.1",
-    "@ngageoint/simple-features-wkt-js": "^1.1.1",
     "better-sqlite3": "^8.7.0",
     "geojson": "^0.5.0",
     "json-stable-stringify": "^1.0.2",

--- a/src/cli-error.ts
+++ b/src/cli-error.ts
@@ -2,6 +2,7 @@ import supportsColor from "supports-color";
 
 const COLORS = {
   RED: "\x1b[41m",
+  YELLOW: "\x1b[43;1m",
   RESET: "\x1b[0m",
 };
 
@@ -12,6 +13,16 @@ export function Bye(message: string, ...optionalParams: any[]): never {
       `${COLORS.RED} Fatal error: ${COLORS.RESET} ${message}`,
       ...optionalParams,
     );
-  else console.error(`Fatal error: ${message}`, ...optionalParams);
+  else console.error(`# Fatal error: ${message}`, ...optionalParams);
   process.exit(500);
+}
+
+/** Report an non-fatal issue */
+export function Warn(message: string, ...optionalParams: any[]): void {
+  if (supportsColor.stderr)
+    console.warn(
+      `${COLORS.YELLOW} Warning: ${COLORS.RESET} ${message}`,
+      ...optionalParams,
+    );
+  else console.warn(`# Warning: ${message}`, ...optionalParams);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -86,11 +86,12 @@ async function cli() {
 
   // If there's a bounding box CRS defined, first check if we can parse it.
   // This is less expensive than converting quads etc.
-  const converter = argv.boundingBoxCrs
+  // TODO: Can we remove this reference to WGS84?
+  const bboxConverter = argv.boundingBoxCrs
     ? await getWGS84Converter(argv.boundingBoxCrs)
-    : WGS84_CODE;
+    : await getWGS84Converter(WGS84_CODE);
   const boundingBox = argv.boundingBox
-    ? suppliedBoundingBox(argv.boundingBox, converter)
+    ? suppliedBoundingBox(argv.boundingBox, bboxConverter)
     : undefined;
 
   // If there's a target file, open a write stream and determine the mimetype off of it.

--- a/src/models/facade-x/featuredao-helper.ts
+++ b/src/models/facade-x/featuredao-helper.ts
@@ -1,0 +1,8 @@
+import type { FeatureDao } from "@ngageoint/geopackage/dist/lib/features/user/featureDao.js";
+import type { FeatureRow } from "@ngageoint/geopackage/dist/lib/features/user/featureRow.js";
+
+export function* queryAllFeatures(
+  dao: FeatureDao<FeatureRow>,
+): IterableIterator<FeatureRow> {
+  for (const result of dao.queryForEach()) yield dao.getRow(result);
+}

--- a/src/models/facade-x/rdf-feature-table.ts
+++ b/src/models/facade-x/rdf-feature-table.ts
@@ -1,9 +1,14 @@
-import { FeatureConverter } from "@ngageoint/simple-features-geojson-js";
-import { GeometryWriter } from "@ngageoint/simple-features-wkt-js";
+import {
+  GeoPackage,
+  GeometryData,
+  SpatialReferenceSystem,
+} from "@ngageoint/geopackage";
+import type { FeatureRow } from "@ngageoint/geopackage/dist/lib/features/user/featureRow.js";
 import type * as RDF from "@rdfjs/types";
-import type { Feature, Geometry } from "geojson";
+import type { Feature } from "geojson";
 import stringify from "json-stable-stringify";
 import { DataFactory } from "rdf-data-factory";
+import { Warn } from "../../cli-error.js";
 import { GEO, RDFNS } from "../../prefixes.js";
 import { enumerate } from "../../py-enumerate.js";
 import {
@@ -16,42 +21,70 @@ import {
 
 const DF = new DataFactory();
 
-/** An OGC Simple Features WKT string representation from a GeoJSON Geometry */
-function sfWKTFromGeoJSONGeometry(geometry: Geometry): string {
-  const sf =
-    FeatureConverter.toSimpleFeaturesGeometryFromGeometryObject(geometry);
-  return GeometryWriter.writeGeometry(sf);
+function srsOpengisUrl(srs: SpatialReferenceSystem) {
+  const { organization, organization_coordsys_id: id } = srs;
+
+  return `http://www.opengis.net/def/crs/${organization.toUpperCase()}/0/${id}`;
 }
 
 /** Generate GeoSPARQL quads from a feature's geometry */
 export function* quadsForGeometry(
-  geometry: Geometry,
+  origData: GeometryData,
+  geoJSONData: Feature | undefined,
   subject: RDF.Quad_Subject,
   graph: RDF.Quad_Graph,
+  options: QuadsFromTableOptions,
 ) {
-  const geo = DF.blankNode();
+  // The underlying libraries (as of writing) do not support all
+  // types of geometries. {geoJSONData} and {origData.geometry}
+  // can therefore be empty.
 
   yield DF.quad(subject, RDFNS("type"), GEO("Feature"), graph);
+  const geometry = origData.geometry;
+
+  if (
+    geometry === undefined ||
+    origData.geometryError ||
+    geoJSONData === undefined
+  )
+    return Warn(
+      `Feature geometry type not supported in ${options.tableName} (_:${subject.value}) (skipped)`,
+    );
+
+  const geo = DF.blankNode();
   yield DF.quad(subject, GEO("hasDefaultGeometry"), geo, graph);
   yield DF.quad(geo, RDFNS("type"), GEO("Geometry"), graph);
 
-  yield DF.quad(
-    geo,
-    GEO("asGeoJSON"),
-    DF.literal(stringify(geometry), GEO("geoJSONLiteral")),
-    graph,
-  );
+  const { srs } = options;
+  const wktLiteral = `<${srsOpengisUrl(srs)}> ${geometry.toWkt()}`;
+
   yield DF.quad(
     geo,
     GEO("asWKT"),
-    DF.literal(sfWKTFromGeoJSONGeometry(geometry), GEO("wktLiteral")),
+    DF.literal(wktLiteral, GEO("wktLiteral")),
+    graph,
+  );
+
+  // Q: Is this the only identifier of WGS84 herein?
+  const isWGS84 =
+    `${srs.organization}:${srs.organization_coordsys_id}` == "EPSG:4326";
+
+  // See issue https://github.com/redmer/rdf-geopackage/issues/19
+  const wgs84Geom = isWGS84 ? geo : DF.blankNode();
+  yield DF.quad(subject, GEO("hasDefaultGeometry"), wgs84Geom, graph);
+  yield DF.quad(wgs84Geom, RDFNS("type"), GEO("Geometry"), graph);
+
+  yield DF.quad(
+    wgs84Geom,
+    GEO("asGeoJSON"),
+    DF.literal(stringify(geoJSONData.geometry), GEO("geoJSONLiteral")),
     graph,
   );
 }
 
 /** Generate RDF quads from a GeoPackage feature table */
 export function* quadsFromFeatureTable(
-  iterator: IterableIterator<Feature>,
+  iterator: IterableIterator<FeatureRow>,
   options: QuadsFromTableOptions,
 ) {
   const graph = getTableNode(options.tableName);
@@ -63,7 +96,13 @@ export function* quadsFromFeatureTable(
     );
 
     yield* quadsForTableAndRow(graph, subject, i);
-    yield* quadsForAttributes(feature.properties, subject, graph, options);
-    yield* quadsForGeometry(feature.geometry, subject, graph);
+    yield* quadsForAttributes(feature.values, subject, graph, options);
+    yield* quadsForGeometry(
+      feature.geometry,
+      GeoPackage.parseFeatureRowIntoGeoJSON(feature, options.srs),
+      subject,
+      graph,
+      options,
+    );
   }
 }

--- a/src/models/facade-x/rdf-table-common.ts
+++ b/src/models/facade-x/rdf-table-common.ts
@@ -1,3 +1,4 @@
+import type { SpatialReferenceSystem } from "@ngageoint/geopackage";
 import type { DBValue } from "@ngageoint/geopackage/dist/lib/db/dbAdapter.js";
 import type * as RDF from "@rdfjs/types";
 import { DataFactory } from "rdf-data-factory";
@@ -12,6 +13,8 @@ export interface QuadsFromTableOptions {
   baseIRI: string;
   /** See {@link GeoPackageOptions}  */
   includeBinaryValues?: boolean;
+  /** Spatial Reference System of this table */
+  srs?: SpatialReferenceSystem;
 }
 
 const DF = new DataFactory();


### PR DESCRIPTION
Originally, WKT geometries were derived from the (WGS84) GeoJSON geometries. After finding #21, this update fixes #14 and now `rdf-geopackage` outputs the geometry in the original CRS. 

The tool also now warns if feature geometries are not convertible to GeoJSON or WKT: these are due to unsupported types of non-linear geometries in the used libraries.

Fixes #14